### PR TITLE
Modified Wisteria Poison Effect to Slow Entities

### DIFF
--- a/src/main/java/dev/overgrown/quirks/effect/wisteria/WisteriaPoisonStatusEffect.java
+++ b/src/main/java/dev/overgrown/quirks/effect/wisteria/WisteriaPoisonStatusEffect.java
@@ -2,14 +2,29 @@ package dev.overgrown.quirks.effect.wisteria;
 
 import dev.overgrown.quirks.Quirks;
 import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectCategory;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
 
+import java.util.UUID;
+
 public class WisteriaPoisonStatusEffect extends StatusEffect {
+    // Custom UUID for the movement speed modifier
+    private static final UUID MOVEMENT_SPEED_MODIFIER_ID = UUID.fromString("7107DE5E-7CE8-4030-940E-514C1F160891");
+
     public WisteriaPoisonStatusEffect() {
         super(StatusEffectCategory.HARMFUL, 0x8A2BE2); // Purple color
+
+        // Add attribute modifier for movement speed reduction
+        this.addAttributeModifier(
+                EntityAttributes.GENERIC_MOVEMENT_SPEED,
+                MOVEMENT_SPEED_MODIFIER_ID.toString(),
+                -0.20, // 20% reduction per level
+                EntityAttributeModifier.Operation.MULTIPLY_TOTAL
+        );
     }
 
     @Override


### PR DESCRIPTION
Added imports for `EntityAttributeModifier`, `EntityAttributes`, and `UUID` and a UUID for the movement speed modifier to avoid conflicts with other effects. In the constructor, added an attribute modifier that reduces movement speed by 20% per effect level, using the same operation (`MULTIPLY_TOTAL`) as the vanilla slowness effect.